### PR TITLE
Fix undefined variable in text analysis

### DIFF
--- a/analysis_report/text_analysis.R
+++ b/analysis_report/text_analysis.R
@@ -65,5 +65,6 @@ tm::inspect(tdm)
 m<- as.matrix(tdm)
 dim(m)
 
-tab <- as.matrix(table(cs))
-wordcloud(myCorpus, min.freq=100)
+word.freq <- rowSums(m)
+word.freq <- sort(word.freq, decreasing = TRUE)
+wordcloud(names(word.freq), word.freq, min.freq = 100)


### PR DESCRIPTION
## Summary
- compute word frequencies from TermDocumentMatrix
- generate wordcloud from the frequency data

## Testing
- `pre-commit run --files analysis_report/text_analysis.R` *(fails: command not found)*
- `pip install pre-commit` *(fails: could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6846307448788327aad0a5743da23590